### PR TITLE
[f] Add middleware for basic authentication

### DIFF
--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -51,8 +51,13 @@ export function middleware(request: NextRequest) {
   });
 }
 
+// Excludes from basic auth:
+// - _next/static, _next/image: Next.js internals
+// - favicon.ico: Favicon file
+// - .*\.(svg|png|jpg|jpeg|gif|webp)$: Image files
+// - api/submit: Public CLI submission endpoint
 export const config = {
   matcher: [
-    "/((?!_next/static|_next/image|favicon.ico|.*\\.(?:svg|png|jpg|jpeg|gif|webp)$).*)",
+    "/((?!_next/static|_next/image|favicon.ico|api/submit|.*\\.(?:svg|png|jpg|jpeg|gif|webp)$).*)",
   ],
 };


### PR DESCRIPTION
**[f] Add middleware for basic authentication**
- Implement HTTP Basic Authentication middleware
- Store credentials securely using environment secrets
- Apply authentication to all routes/resources
- Maintain single set of shared credentials for organizational access
- Exclude static files

https://tracker.eastagile.com/east-agile/projects/36461400-433c-42e6-91fb-3c4cf572078c/issues/e423592d-034d-4921-ac0e-aab057ece7b3