### PR TITLE
[f] Display GitHub full names on leaderboard

### DIFF
--- a/convex/submissions.ts
+++ b/convex/submissions.ts
@@ -750,7 +750,7 @@ export const fetchGitHubUserData = action({
       if (response.ok) {
         const userData = await response.json();
         return {
-          name: userData.name || null,
+          name: userData.name || username,
           avatar: userData.avatar_url || null
         };
       }
@@ -758,7 +758,7 @@ export const fetchGitHubUserData = action({
       console.warn(`Error fetching GitHub data for ${username}:`, error);
     }
 
-    return { name: null, avatar: null };
+    return { name: username, avatar: null };
   },
 });
 
@@ -806,14 +806,13 @@ export const updateGitHubNames = action({
     for (const { id, username } of submissionsToUpdate) {
       const githubData = await ctx.runAction(api.submissions.fetchGitHubUserData, { username });
 
-      if (githubData.name || githubData.avatar) {
-        await ctx.runMutation(api.submissions.updateSubmissionGitHubData, {
-          submissionId: id,
-          githubName: githubData.name || undefined,
-          githubAvatar: githubData.avatar || undefined,
-        });
-        updated++;
-      }
+      // Always update since we now guarantee a name (either from GitHub or fallback to username)
+      await ctx.runMutation(api.submissions.updateSubmissionGitHubData, {
+        submissionId: id,
+        githubName: githubData.name,  // Will always have a value now
+        githubAvatar: githubData.avatar || undefined,
+      });
+      updated++;
     }
 
     return { updated };

--- a/src/components/Leaderboard.tsx
+++ b/src/components/Leaderboard.tsx
@@ -3,7 +3,7 @@
 import { useState, useEffect } from "react";
 import { motion, AnimatePresence } from "framer-motion";
 import { Trophy, Medal, Award, DollarSign, Zap, Calendar, User, Share2, X, ChevronDown, ArrowUpRight, ChevronLeft, ChevronRight, BadgeCheck } from "lucide-react";
-import { useQuery, useAction } from "convex/react";
+import { useQuery, useAction, useMutation } from "convex/react";
 import { api } from "../../convex/_generated/api";
 import Link from "next/link";
 import ShareCard from "./ShareCard";
@@ -22,7 +22,8 @@ export default function Leaderboard() {
   // No session needed - authentication removed
 
   const ITEMS_PER_PAGE = 25;
-  const updateGitHubNames = useAction(api.submissions.updateGitHubNames);
+  const fetchGitHubName = useAction(api.submissions.fetchGitHubName);
+  const updateSubmissionGitHubName = useMutation(api.submissions.updateSubmissionGitHubName);
 
   // Use different queries based on whether date filtering is active
   const hasDateFilter = dateFrom && dateTo;
@@ -60,26 +61,39 @@ export default function Leaderboard() {
   const totalPages = result?.totalPages || 0;
   const currentPage = hasDateFilter ? dateFilterPage : page;
 
-  // Check for submissions without GitHub names and update them
+  // Check for submissions without GitHub names and fetch/update them
   useEffect(() => {
     if (paginatedSubmissions && paginatedSubmissions.length > 0) {
-      const submissionsWithoutNames = paginatedSubmissions
-        .filter(sub => sub.githubUsername && !sub.githubName)
-        .map(sub => sub._id);
+      const updateMissingGitHubNames = async () => {
+        for (const submission of paginatedSubmissions) {
+          // Skip if no GitHub username or already has a name
+          if (!submission.githubUsername || submission.githubName) {
+            continue;
+          }
 
-      if (submissionsWithoutNames.length > 0) {
-        updateGitHubNames({ submissionIds: submissionsWithoutNames })
-          .then(result => {
-            if (result.updated > 0) {
-              console.log(`Updated GitHub names for ${result.updated} submissions`);
-            }
-          })
-          .catch(error => {
-            console.error('Error updating GitHub names:', error);
-          });
-      }
+          try {
+            // Fetch GitHub name using Convex action
+            const githubData = await fetchGitHubName({
+              githubUsername: submission.githubUsername
+            });
+
+            // Update submission with fetched name
+            await updateSubmissionGitHubName({
+              submissionId: submission._id,
+              githubName: githubData.name,
+              githubAvatar: githubData.avatar || undefined
+            });
+
+            console.log(`Updated GitHub name for ${submission.githubUsername}: ${githubData.name}`);
+          } catch (error) {
+            console.error(`Error updating GitHub name for ${submission.githubUsername}:`, error);
+          }
+        }
+      };
+
+      updateMissingGitHubNames();
     }
-  }, [paginatedSubmissions, updateGitHubNames]);
+  }, [paginatedSubmissions, fetchGitHubName, updateSubmissionGitHubName]);
 
   const getRankDisplay = (rank: number) => {
     if (rank === 1) return (


### PR DESCRIPTION
**Description:**
- Adds functionality to fetch and display GitHub users' full names alongside their usernames on the leaderboard.

**Technical Details**
- Automatically fetches missing GitHub names when leaderboard loads
- Automatically fetches missing GitHub names when profile loads
- Caches fetched data in database to avoid repeated API calls
- Displays format: Full Name with @username in smaller text below

https://tracker.eastagile.com/east-agile/projects/36461400-433c-42e6-91fb-3c4cf572078c/issues/c4959899-7225-405b-b7db-bbec4eaefb59